### PR TITLE
QC Service Function Skeleton

### DIFF
--- a/web_application/Backend/FlaskApp/app.py
+++ b/web_application/Backend/FlaskApp/app.py
@@ -697,6 +697,15 @@ def calculate_cofficients():
     #except DoesNotExist:
     #    return jsonify({'message': 'Collaboration not found'}), 404
 
+def quality_control_service(collaboration_id, qc_threshold):
+    metadata_ids = get_metadata_ids(collabortaion_id) # retrieves from collaboration store
+    metadata = get_metadata(metadata_ids) #retrieves from metadata store
+
+    quality_control_result = quality_control_algorithm(qc_threshold, metadata) # computes the quality control result
+    set_quality_control_result(quality_control_result) # puts result into QC store
+
+    return quality_control_result # for the frontend
+
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
Added a function called quality control service that takes inputs collaboration_id and qc_threshold from the frontend that retrieves the metadata ids and metadata and computes the quality control result. This result is saved to the QC data store and also returned to the front end. This pull request is for the skeleton with the placeholder functions to demonstrate the logic.